### PR TITLE
Allow other registries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,18 @@ inputs:
     description: What Container/Dockerfile to use for the build. Defaults to Dockerfile.
     default: Dockerfile
   github_token:
-    description: The Github Auth Token.
+    description: The Github Auth Token. Used to publish to the registry.
     required: true
   publish:
     description: Whether to publish the container or not.
     default: 'true'
+  registry:
+    description: The registry to publish to.
+    default: ghcr.io
+  registry_username:
+    description: The username to use for the registry.
+    required: true
+    default: ${{ github.repository_owner }}
 
 runs:
   using: "composite"
@@ -35,8 +42,8 @@ runs:
       uses: docker/login-action@v3
       if: ${{ inputs.publish == 'true' }}
       with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry_username }}
         password: ${{ inputs.github_token }}
 
     - name: Get the tags

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,6 @@ inputs:
   buildfile:
     description: What Container/Dockerfile to use for the build. Defaults to Dockerfile.
     default: Dockerfile
-  github_token:
-    description: The Github Auth Token. Used to publish to the registry.
-    required: true
   publish:
     description: Whether to publish the container or not.
     default: 'true'
@@ -21,8 +18,10 @@ inputs:
     default: ghcr.io
   registry_username:
     description: The username to use for the registry.
-    required: true
     default: ${{ github.repository_owner }}
+  registry_password:
+    description: The password to use for the registry.
+    default: ${{ secrets.GITHUB_TOKEN }}
 
 runs:
   using: "composite"
@@ -44,7 +43,7 @@ runs:
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry_username }}
-        password: ${{ inputs.github_token }}
+        password: ${{ inputs.registry_password }}
 
     - name: Get the tags
       shell: bash


### PR DESCRIPTION
introduce 3 new parameters and remove one

add:
- registry - the name of the registry, defaults to github
- registry_username - login name for a registry, defaults to github.repository_owner
- registry_password - password for a registry, defaults to GITHUB_TOKEN

remove:
- github_token - old name for the login password