### PR TITLE
quick fix bug with docker.io login

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,13 +52,13 @@ runs:
         username: ${{ inputs.registry_username }}
         password: ${{ inputs.registry_password }}
 
-    - name: Log in to the Docker container registry
-      uses: docker/login-action@v3
-      if: ${{ inputs.publish == 'true' }} && ${{ inputs.docker_username != '' }} && ${{ inputs.docker_password != '' }}
-      with:
-        registry: docker.io
-        username: ${{ inputs.docker_username }}
-        password: ${{ inputs.docker_password }}
+    # - name: Log in to the Docker container registry
+    #   uses: docker/login-action@v3
+    #   if: ${{ inputs.publish == 'true' }} && ${{ inputs.docker_username != '' }} && ${{ inputs.docker_password != '' }}
+    #   with:
+    #     registry: docker.io
+    #     username: ${{ inputs.docker_username }}
+    #     password: ${{ inputs.docker_password }}
 
     - name: Get the tags
       shell: bash


### PR DESCRIPTION
somehow the docker.io login is triggered, but it shouldn't as long as you dont set the credentials.