### PR TITLE
refactor container tagging. allow to set custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jobs:
       packages: write
     steps:
       - name: Build and publish a container
-        uses: voxpupuli/gha-build-and-publish-a-container@v1
+        uses: voxpupuli/gha-build-and-publish-a-container@v2
         with:
           registry: docker.io                 # Default: ghcr.io
           registry_username: foobar           # Default: github.repository_owner
@@ -26,8 +26,13 @@ jobs:
           build_context: 'puppetdb'           # Default: .
           buildfile: Dockerfile.something     # Default: Dockerfile
           publish: 'false'                    # Default: 'true'
-          docker_username: 'someone'          # No default
-          docker_password: 'docker hub pass'  # No default
+          docker_username: 'someone'          # No default, can be empty
+          docker_password: 'docker hub pass'  # No default, can be empty
+          tags: |                             # No default, can be empty
+            docker.io/${{ env.REPOSITORY }}:3.2
+            docker.io/${{ env.REPOSITORY }}:latest
+            ghcr.io/${{ env.REPOSITORY }}:3.2
+            ghcr.io/${{ env.REPOSITORY }}:latest
 ```
 
 Test container build in ci:
@@ -41,10 +46,11 @@ jobs:
       packages: read
     steps:
     - name: Test container build
-      uses: voxpupuli/gha-build-and-publish-a-container@v1
+      uses: voxpupuli/gha-build-and-publish-a-container@v2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish: 'false'
+        tags: ci/test:dummy
 ```
 
 # Behavior

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ jobs:
           docker_username: 'someone'          # No default, can be empty
           docker_password: 'docker hub pass'  # No default, can be empty
           tags: |                             # No default, can be empty
-            docker.io/${{ env.REPOSITORY }}:3.2
-            docker.io/${{ env.REPOSITORY }}:latest
-            ghcr.io/${{ env.REPOSITORY }}:3.2
-            ghcr.io/${{ env.REPOSITORY }}:latest
+            docker.io/${{ github.repository }}:3.2
+            docker.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:3.2
+            ghcr.io/${{ github.repository }}:latest
 ```
 
 Test container build in ci:

--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ jobs:
 
 ## Tagging
 
-The `main`-branch will always be tagged with the `development` container-tag.
+The git `main`-branch will automatically be tagged with the `development` container-tag, if no custom tags are supplied.
 If one does a git-tag like `v1.0.0` this will translate into `1.0.0` container-tag.
 The last git-tag also will be tagged with the `latest` container-tag.
+If custom tags are supplied, this rules are not valid anymore.
+The tags which are supplied will then be used. The tags have to be supplied in a newline seperated list.
+The format is: `registry/user/repo:tag-name`.
 
 ## Push to hub.docker.com
 
 If you specify a docker_username and a docker_password, the action will do a second registry login.
-It will then automatically also log in to docker.io and on push the image gets published on your
-primary registry and additionally to hub.docker.com.
+It will then automatically also log in to docker.io. To push images to docker.io you have to add tags with the docker.io registry path in front.
+
+f.e.:
+```yaml
+tags: |
+  ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ matrix.release }}
+  docker.io/${{ github.repository }}:${{ github.ref_name }}-${{ matrix.release }}
+  ghcr.io/${{ github.repository }}:latest
+  docker.io/${{ github.repository }}:latest
+```

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ inputs:
     description: The username to use for the docker registry.
   docker_password:
     description: The password to use for the docker registry.
+  tags:
+    description: The tags to use for the container. This is a string of tags seperated by a newline.
 
 runs:
   using: "composite"
@@ -62,7 +64,7 @@ runs:
 
     - name: Get the tags
       shell: bash
-      if: ${{ inputs.publish == 'true' }}
+      if: ${{ inputs.publish == 'true' && inputs.tags == '' }}
       run: ${{ github.action_path }}/get_the_tags.py --repo "${{ github.repository }}" --ref "${{ github.ref_name }}" --log DEBUG
       id: tags
 
@@ -75,6 +77,6 @@ runs:
         platforms: ${{ inputs.build_arch }}
         push: ${{ inputs.publish == 'true' }}
         # if publish is false, tag as test, otherwise use the tags from the previous step
-        tags: ${{ inputs.publish == 'true' && steps.tags.outputs.tags || 'ci/test:dummy' }}
+        tags: ${{ inputs.publish == 'true' && steps.tags.outputs.tags || inputs.tags }}
         file: ${{ inputs.buildfile }}
         build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
- you can now set customs tags
- if you don't the standard behavior ist to generate them from the ref_name and git tags
- if you do the automatic script will not be triggered and only the specified tags will be used

the syntax for specifying tags is:
```yaml
tags: |
  registry/user/repository_name:v1.2.3
  registry/user/repository_name:latest
```